### PR TITLE
adding writeToProfile target options

### DIFF
--- a/src/deno.ts
+++ b/src/deno.ts
@@ -10,11 +10,11 @@ Object.assign(writeContext, {
   karabinerConfigFile() {
     return join(this.karabinerConfigDir(), 'karabiner.json')
   },
-  readKarabinerConfig() {
-    return JSON.parse(Deno.readTextFileSync(this.karabinerConfigFile()))
+  readKarabinerConfig(karabinerJsonPath?: string) {
+    return JSON.parse(Deno.readTextFileSync(karabinerJsonPath ?? this.karabinerConfigFile()))
   },
-  writeKarabinerConfig(json: any) {
-    return Deno.writeTextFile(this.karabinerConfigFile(), json)
+  writeKarabinerConfig(json: any, karabinerJsonPath?: string) {
+    return Deno.writeTextFile(karabinerJsonPath ?? this.karabinerConfigFile(), json)
   },
   exit(code = 0): never {
     Deno.exit(code)


### PR DESCRIPTION
Hi There,

first of all, I'm really enjoying karabiner.ts - thanks for publishing it! 

I'd like to propose this small change to the `writeToProfile` function to support people who keep their karabiner.json files in different locations. Granted this is pretty atypical, this change will facilitate people, like me, who are using nix home-manager and are looking to use karabiner.ts to update the source karabiner.json file (not the currently installed version).

Let me know what you think. Thanks!