### PR TITLE
✨ Add `toNewApp` method

### DIFF
--- a/editor/rules.js
+++ b/editor/rules.js
@@ -5,7 +5,7 @@ rule, layer, simlayer, hyperLayer, modifierLayer, duoLayer,
 // from / map()
 map, mapConsumerKey, mapPointingButton, mapSimultaneous, mapDoubleTap, mouseMotionToScroll,
 // to
-toKey, toConsumerKey, toPointingButton, toHyper, toSuperHyper, toMeh, to$, toApp, toPaste, toTypeSequence, toNone, toNotificationMessage, toRemoveNotificationMessage, toInputSource, toSetVar, toMouseKey, toMouseCursorPosition, toStickyModifier, toCgEventDoubleClick, toSleepSystem,
+toKey, toConsumerKey, toPointingButton, toHyper, toSuperHyper, toMeh, to$, toApp, toNewApp, toPaste, toTypeSequence, toNone, toNotificationMessage, toRemoveNotificationMessage, toInputSource, toSetVar, toMouseKey, toMouseCursorPosition, toStickyModifier, toCgEventDoubleClick, toSleepSystem,
 // conditions
 ifApp, ifDevice, ifVar, ifDeviceExists, ifInputSource, ifKeyboardType, ifEventChanged,
 // utils

--- a/src/config/manipulator.test.ts
+++ b/src/config/manipulator.test.ts
@@ -77,17 +77,19 @@ describe('ManipulatorBuilder', () => {
     ])
   })
 
-  test('to$(), toApp(), toPaste()', () => {
+  test('to$(), toApp(), toNewApp(), toPaste()', () => {
     const to = new BasicManipulatorBuilder(from)
       .to$('cd')
       .toApp('Finder')
       .toApp('Xcode.app')
+      .toNewApp('Terminal')
       .toPaste('test')
       .build()[0].to as Array<{ shell_command: string }>
     expect(to[0]).toEqual({ shell_command: 'cd' })
     expect(to[1]).toEqual({ shell_command: 'open -a "Finder".app' })
     expect(to[2]).toEqual({ shell_command: 'open -a "Xcode".app' })
-    expect(to[3].shell_command).toMatch('"test"')
+    expect(to[3]).toEqual({ shell_command: 'open -n -a "Terminal".app' })
+    expect(to[4].shell_command).toMatch('"test"')
   })
 
   test('toApp() with space in name', () => {

--- a/src/config/manipulator.ts
+++ b/src/config/manipulator.ts
@@ -24,6 +24,7 @@ import { toTypeSequence } from './to-type-sequence.ts'
 import {
   to$,
   toApp,
+  toNewApp,
   toCgEventDoubleClick,
   toConsumerKey,
   toHyper,
@@ -137,6 +138,12 @@ export class BasicManipulatorBuilder implements ManipulatorBuilder {
   /** Map to `$ open -a {app}.app` */
   toApp(app: string): this {
     this.addToEvent(toApp(app))
+    return this
+  }
+
+  /** Map to `$ open -n -a {app}.app` */
+  toNewApp(app: string): this {
+    this.addToEvent(toNewApp(app))
     return this
   }
 

--- a/src/config/to.ts
+++ b/src/config/to.ts
@@ -106,6 +106,12 @@ export function toApp(app: string): ToEvent {
   return to$(`open -a "${matched?.[1] || app}".app`)
 }
 
+/** Create ToEvent with shell_command `open -n -a {app}.app` */
+export function toNewApp(app: string): ToEvent {
+  const matched = app.match(/^"?(.*?)(.app)?"?$/)
+  return to$(`open -n -a "${matched?.[1] || app}".app`)
+}
+
 /** Create ToEvent with shell_command to paste {text} */
 export function toPaste(text: string): ToEvent {
   return to$(`osascript -e '


### PR DESCRIPTION
Thank you for great product!

This provides type safety and is usefull writing safe configuration files!

In my usecase, I want to exec shell command `open -n -a "Some".app`, but currently I have no choise but to use functions such as `to$`, which is a little inconvenient.

So, I added `toNewApp` like `toApp`.

Now, this PR includes only sample implementations.

If you want to implement onother way like that adding options to `toApp`, I'll fix this PR.