### PR TITLE
Add generic_desktop toEvent

### DIFF
--- a/src/config/manipulator.ts
+++ b/src/config/manipulator.ts
@@ -26,6 +26,7 @@ import {
   toApp,
   toCgEventDoubleClick,
   toConsumerKey,
+  toGenericDesktop,
   toHyper,
   toInputSource,
   toKey,
@@ -116,6 +117,16 @@ export class BasicManipulatorBuilder implements ManipulatorBuilder {
     options?: ToEventOptions,
   ): this {
     this.addToEvent(toConsumerKey(code, modifiers, options))
+    return this
+  }
+
+  /** To { consumer_key_code } */
+  toGenericDesktop(
+    code: number,
+    modifiers?: ModifierParam,
+    options?: ToEventOptions,
+  ): this {
+    this.addToEvent(toGenericDesktop(code, modifiers, options))
     return this
   }
 

--- a/src/config/manipulator.ts
+++ b/src/config/manipulator.ts
@@ -120,7 +120,7 @@ export class BasicManipulatorBuilder implements ManipulatorBuilder {
     return this
   }
 
-  /** To { consumer_key_code } */
+  /** To { generic_desktop } */
   toGenericDesktop(
     code: number,
     modifiers?: ModifierParam,

--- a/src/config/to.ts
+++ b/src/config/to.ts
@@ -82,6 +82,19 @@ export function toConsumerKey(
   }
 }
 
+/** Create ToEvent with generic_desktop code */
+export function toGenericDesktop(
+  code: number,
+  modifiers?: ModifierParam,
+  options?: ToEventOptions,
+): ToEvent {
+  return {
+    ...options,
+    generic_desktop: code,
+    modifiers: modifiers ? parseModifierParam(modifiers) : undefined,
+  }
+}
+
 /** Create ToEvent with pointing_button */
 export function toPointingButton(
   button: PointingButton,

--- a/src/karabiner/karabiner-config.ts
+++ b/src/karabiner/karabiner-config.ts
@@ -148,6 +148,7 @@ export type ToEvent = (
   | { mouse_key: ToMouseKey }
   | { sticky_modifier: ToStickyModifier }
   | { software_function: ToSoftwareFunction }
+  | { generic_desktop: number }
 ) &
   ToEventOptions
 


### PR DESCRIPTION
I was searching for a fix for my problem and found this post: https://github.com/pqrs-org/Karabiner-Elements/issues/2516#issuecomment-2920826840

It talks about generic_desktop event with a 155 code that acts as "DoNotDisturb" key (F6 on newer macs)

I couldn't find a way to achieve this with karabiner.ts

So I created a small modification that solved it for me and now am offering it upstream. Cheers!