### PR TITLE
Add support for features from KE 15

### DIFF
--- a/docs/docs/manipulators/condition.md
+++ b/docs/docs/manipulators/condition.md
@@ -46,6 +46,11 @@ type Condition =
       value: boolean
       description?: string
     }
+  | {
+      type: 'expression_if' | 'expression_unless'
+      expression: string
+      description?: string
+    }
 ```
 
 </details>
@@ -59,6 +64,7 @@ ifDeviceExists() // device_exists_if
 ifKeyboardType() // keyboard_type_if 
 ifInputSource() // input_source_if 
 ifVar() // variable_if 
+ifExpression() // expression_if
 ifEventChanged() // event_changed_if 
 ```
 

--- a/docs/docs/manipulators/from.md
+++ b/docs/docs/manipulators/from.md
@@ -22,6 +22,7 @@ export type FromEvent = (
   | { simultaneous: Array</*...*/>, simultaneous_options?: {/*...*/} }
 ) & {
   modifiers?: { mandatory?: [/*...*/], optional?: [/*...*/] }
+  integer_value?: number
 }
 ```
 

--- a/docs/docs/manipulators/to.md
+++ b/docs/docs/manipulators/to.md
@@ -195,6 +195,7 @@ The other `to*()` methods to create `ToEvent`:
 ```typescript
 toInputSource()
 toSetVar()
+toSetVarExpression()
 toNotificationMessage()
 toRemoveNotificationMessage()
 toMouseKey()

--- a/docs/docs/manipulators/to.md
+++ b/docs/docs/manipulators/to.md
@@ -26,6 +26,10 @@ export type ToEvent = (
       set_variable: {
         name: string
         value: number | boolean | string
+        key_up_value?: number | boolean | string
+        expression?: string
+        key_up_expression?: string
+        type?: 'set' | 'unset'
       }
     }
   | { set_notification_message: { id: string; text: string } }

--- a/src/config/condition.test.ts
+++ b/src/config/condition.test.ts
@@ -9,6 +9,7 @@ import {
   ifDevice,
   ifDeviceExists,
   ifEventChanged,
+  ifExpression,
   ifInputSource,
   ifKeyboardType,
   ifVar,
@@ -166,6 +167,19 @@ test('unless()', () => {
   expect(eventChangedUnless.build()).toEqual(
     eventChangedUnless.unless().unless().build(),
   )
+
+  let expressionUnless = ifExpression('a > 0').unless()
+  expect(expressionUnless.build().type).toBe('expression_unless')
+  expect(expressionUnless.build()).toEqual(
+    expressionUnless.unless().unless().build(),
+  )
+})
+
+test('ifExpression()', () => {
+  expect(ifExpression('command_q_expiration > system.now.milliseconds').build()).toEqual({
+    type: 'expression_if',
+    expression: 'command_q_expiration > system.now.milliseconds',
+  })
 })
 
 test('accessibilityVariable constants', () => {

--- a/src/config/condition.test.ts
+++ b/src/config/condition.test.ts
@@ -176,7 +176,9 @@ test('unless()', () => {
 })
 
 test('ifExpression()', () => {
-  expect(ifExpression('command_q_expiration > system.now.milliseconds').build()).toEqual({
+  expect(
+    ifExpression('command_q_expiration > system.now.milliseconds').build(),
+  ).toEqual({
     type: 'expression_if',
     expression: 'command_q_expiration > system.now.milliseconds',
   })

--- a/src/config/condition.ts
+++ b/src/config/condition.ts
@@ -104,7 +104,11 @@ export function ifEventChanged(value = true, description?: string) {
 }
 
 export function ifExpression(expression: string, description?: string) {
-  return new ConditionBuilder({ type: 'expression_if', expression, description })
+  return new ConditionBuilder({
+    type: 'expression_if',
+    expression,
+    description,
+  })
 }
 
 export const accessibilityVariable = {

--- a/src/config/condition.ts
+++ b/src/config/condition.ts
@@ -103,6 +103,10 @@ export function ifEventChanged(value = true, description?: string) {
   return new ConditionBuilder({ type: 'event_changed_if', value, description })
 }
 
+export function ifExpression(expression: string, description?: string) {
+  return new ConditionBuilder({ type: 'expression_if', expression, description })
+}
+
 export const accessibilityVariable = {
   roleString: 'accessibility.focused_ui_element.role_string',
   subroleString: 'accessibility.focused_ui_element.subrole_string',
@@ -120,6 +124,7 @@ let unlessTypes = flipUnlessTypes({
   keyboard_type_if: 'keyboard_type_unless',
   input_source_if: 'input_source_unless',
   variable_if: 'variable_unless',
+  expression_if: 'expression_unless',
   event_changed_if: 'event_changed_unless',
 })
 

--- a/src/config/manipulator.test.ts
+++ b/src/config/manipulator.test.ts
@@ -132,6 +132,22 @@ describe('ManipulatorBuilder', () => {
     ).toEqual([
       { set_variable: { name: 'a', value: 1, key_up_value: 2, type: 'unset' } },
     ])
+    expect(
+      new BasicManipulatorBuilder(from)
+        .toVar('a', 1, 2, 'set', 'x + 1', 'x - 1')
+        .build()[0].to,
+    ).toEqual([
+      {
+        set_variable: {
+          name: 'a',
+          value: 1,
+          key_up_value: 2,
+          type: 'set',
+          expression: 'x + 1',
+          key_up_expression: 'x - 1',
+        },
+      },
+    ])
   })
 
   test('toUnsetVar()', () => {

--- a/src/config/manipulator.test.ts
+++ b/src/config/manipulator.test.ts
@@ -132,17 +132,20 @@ describe('ManipulatorBuilder', () => {
     ).toEqual([
       { set_variable: { name: 'a', value: 1, key_up_value: 2, type: 'unset' } },
     ])
+  })
+
+  test('toVarExpression()', () => {
     expect(
       new BasicManipulatorBuilder(from)
-        .toVar('a', 1, 2, 'set', 'x + 1', 'x - 1')
+        .toVarExpression('a', {
+          expression: 'x + 1',
+          key_up_expression: 'x - 1',
+        })
         .build()[0].to,
     ).toEqual([
       {
         set_variable: {
           name: 'a',
-          value: 1,
-          key_up_value: 2,
-          type: 'set',
           expression: 'x + 1',
           key_up_expression: 'x - 1',
         },
@@ -358,12 +361,7 @@ describe('ManipulatorBuilder', () => {
 
     expect(
       new BasicManipulatorBuilder(from)
-        .toIfOtherKeyPressed(
-          [{ key_code: 'escape' }],
-          'b',
-          '⌘',
-          { lazy: true },
-        )
+        .toIfOtherKeyPressed([{ key_code: 'escape' }], 'b', '⌘', { lazy: true })
         .build()[0].to_if_other_key_pressed,
     ).toEqual([
       {

--- a/src/config/manipulator.ts
+++ b/src/config/manipulator.ts
@@ -177,7 +177,9 @@ export class BasicManipulatorBuilder implements ManipulatorBuilder {
     expression?: ToVariable['expression'],
     key_up_expression?: ToVariable['key_up_expression'],
   ): this {
-    this.addToEvent(toSetVar(name, value, key_up_value, type, expression, key_up_expression))
+    this.addToEvent(
+      toSetVar(name, value, key_up_value, type, expression, key_up_expression),
+    )
     return this
   }
 

--- a/src/config/manipulator.ts
+++ b/src/config/manipulator.ts
@@ -174,8 +174,10 @@ export class BasicManipulatorBuilder implements ManipulatorBuilder {
     value: ToVariable['value'] = 1,
     key_up_value?: ToVariable['key_up_value'],
     type?: ToVariable['type'],
+    expression?: ToVariable['expression'],
+    key_up_expression?: ToVariable['key_up_expression'],
   ): this {
-    this.addToEvent(toSetVar(name, value, key_up_value, type))
+    this.addToEvent(toSetVar(name, value, key_up_value, type, expression, key_up_expression))
     return this
   }
 

--- a/src/config/manipulator.ts
+++ b/src/config/manipulator.ts
@@ -44,6 +44,7 @@ import {
   toRemoveNotificationMessage,
   toSendUserCommand,
   toSetVar,
+  toSetVarExpression,
   toSleepSystem,
   toStickyModifier,
   toSuperHyper,
@@ -174,12 +175,20 @@ export class BasicManipulatorBuilder implements ManipulatorBuilder {
     value: ToVariable['value'] = 1,
     key_up_value?: ToVariable['key_up_value'],
     type?: ToVariable['type'],
-    expression?: ToVariable['expression'],
-    key_up_expression?: ToVariable['key_up_expression'],
   ): this {
-    this.addToEvent(
-      toSetVar(name, value, key_up_value, type, expression, key_up_expression),
-    )
+    this.addToEvent(toSetVar(name, value, key_up_value, type))
+    return this
+  }
+
+  /** Map to setting a variable using expressions */
+  toVarExpression(
+    name: string,
+    options: {
+      expression: string
+      key_up_expression?: string
+    },
+  ): this {
+    this.addToEvent(toSetVarExpression(name, options))
     return this
   }
 

--- a/src/config/to.test.ts
+++ b/src/config/to.test.ts
@@ -6,6 +6,7 @@ import {
   toPlaySound,
   toSendUserCommand,
   toSetVar,
+  toSetVarExpression,
   toUnsetVar,
 } from './to'
 
@@ -53,13 +54,24 @@ test('setVar()', () => {
       type: 'unset',
     },
   })
-  expect(toSetVar('test', 1, 2, 'set', 'x + 1')).toEqual({
+  expect(toSetVar('test', 1, 2, 'set')).toEqual({
     set_variable: {
       name: 'test',
       value: 1,
       key_up_value: 2,
       type: 'set',
+    },
+  })
+  expect(
+    toSetVarExpression('test', {
       expression: 'x + 1',
+      key_up_expression: 'x - 1',
+    }),
+  ).toEqual({
+    set_variable: {
+      name: 'test',
+      expression: 'x + 1',
+      key_up_expression: 'x - 1',
     },
   })
 })

--- a/src/config/to.test.ts
+++ b/src/config/to.test.ts
@@ -53,6 +53,15 @@ test('setVar()', () => {
       type: 'unset',
     },
   })
+  expect(toSetVar('test', 1, 2, 'set', 'x + 1')).toEqual({
+    set_variable: {
+      name: 'test',
+      value: 1,
+      key_up_value: 2,
+      type: 'set',
+      expression: 'x + 1',
+    },
+  })
 })
 
 test('toUnsetVar()', () => {

--- a/src/config/to.ts
+++ b/src/config/to.ts
@@ -171,17 +171,23 @@ export function toSetVar(
   value: ToVariable['value'] = 1,
   key_up_value?: ToVariable['key_up_value'],
   type?: ToVariable['type'],
-  expression?: ToVariable['expression'],
-  key_up_expression?: ToVariable['key_up_expression'],
+): ToEvent {
+  return { set_variable: { name, value, key_up_value, type } }
+}
+
+/** Create ToEvent with set_variable using expressions */
+export function toSetVarExpression(
+  name: string,
+  options: {
+    expression: string
+    key_up_expression?: string
+  },
 ): ToEvent {
   return {
     set_variable: {
       name,
-      value,
-      key_up_value,
-      type,
-      expression,
-      key_up_expression,
+      expression: options.expression,
+      key_up_expression: options.key_up_expression,
     },
   }
 }

--- a/src/config/to.ts
+++ b/src/config/to.ts
@@ -171,8 +171,10 @@ export function toSetVar(
   value: ToVariable['value'] = 1,
   key_up_value?: ToVariable['key_up_value'],
   type?: ToVariable['type'],
+  expression?: ToVariable['expression'],
+  key_up_expression?: ToVariable['key_up_expression'],
 ): ToEvent {
-  return { set_variable: { name, value, key_up_value, type } }
+  return { set_variable: { name, value, key_up_value, type, expression, key_up_expression } }
 }
 
 /** Create ToEvent with set_variable: { type: 'unset' } */

--- a/src/config/to.ts
+++ b/src/config/to.ts
@@ -174,7 +174,16 @@ export function toSetVar(
   expression?: ToVariable['expression'],
   key_up_expression?: ToVariable['key_up_expression'],
 ): ToEvent {
-  return { set_variable: { name, value, key_up_value, type, expression, key_up_expression } }
+  return {
+    set_variable: {
+      name,
+      value,
+      key_up_value,
+      type,
+      expression,
+      key_up_expression,
+    },
+  }
 }
 
 /** Create ToEvent with set_variable: { type: 'unset' } */

--- a/src/karabiner/consumer-key-code.ts
+++ b/src/karabiner/consumer-key-code.ts
@@ -29,6 +29,13 @@ export let fromAndToConsumerKeyCodes = [
 export let fromOnlyConsumerKeyCodes = [
   // Media controls
   'menu', // Touch ID on Magic Keyboard
+  'stop',
+  'microphone',
+  'selection',
+  'bass_boost',
+  'loudness',
+  'bass_increment',
+  'bass_decrement',
   // Application Launch keys
   'al_graphics_editor',
   'al_database_app',
@@ -97,6 +104,9 @@ export let fromOnlyConsumerKeyCodes = [
   'ac_forward',
   'ac_refresh',
   'ac_bookmarks',
+  'ac_search',
+  'ac_zoom_out',
+  'ac_zoom_in',
   // Remote control buttons
   'menu_pick',
   'menu_up',

--- a/src/karabiner/karabiner-config.ts
+++ b/src/karabiner/karabiner-config.ts
@@ -254,6 +254,12 @@ export type Condition =
       description?: string
     }
   | {
+      /** @see https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/conditions/expression/ */
+      type: 'expression_if' | 'expression_unless'
+      expression: string
+      description?: string
+    }
+  | {
       /** @see https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/conditions/event-changed/ */
       type: 'event_changed_if' | 'event_changed_unless'
       value: boolean
@@ -281,6 +287,10 @@ export type InputSourceCondition = Extract<
 export type VariableCondition = Extract<
   Condition,
   { type: 'input_source_if' | 'input_source_unless' }
+>
+export type ExpressionCondition = Extract<
+  Condition,
+  { type: 'expression_if' | 'expression_unless' }
 >
 export type EventChangedCondition = Extract<
   Condition,

--- a/src/karabiner/karabiner-config.ts
+++ b/src/karabiner/karabiner-config.ts
@@ -45,6 +45,8 @@ export type FromEvent = (
 ) & {
   /** @see https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/from/modifiers/ */
   modifiers?: FromModifiers
+  /** @see https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/from/integer-value/ */
+  integer_value?: number
 }
 export type FromKeyCodeEvent = Extract<
   FromEvent,

--- a/src/karabiner/karabiner-config.ts
+++ b/src/karabiner/karabiner-config.ts
@@ -79,6 +79,8 @@ export type ToVariable = {
   name: string
   value?: number | boolean | string
   key_up_value?: number | boolean | string
+  expression?: string
+  key_up_expression?: string
   type?: 'set' | 'unset'
 }
 

--- a/src/karabiner/karabiner-config.ts
+++ b/src/karabiner/karabiner-config.ts
@@ -122,7 +122,11 @@ export type ToNotificationMessage = { id: string; text: string }
 export type ToOpenApplication =
   | { bundle_identifier: string }
   | { file_path: string }
-  | { frontmost_application_history_index: number }
+  | {
+      frontmost_application_history_index: number
+      frontmost_application_history_exclusion_bundle_identifiers?: string[]
+      frontmost_application_history_exclusion_file_paths?: string[]
+    }
 
 /** @see https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to/send-user-command/ */
 export type ToSendUserCommand = {
@@ -206,6 +210,7 @@ export type DeviceIdentifier = {
   vendor_id?: number
   product_id?: number
   location_id?: number
+  device_address?: string
   is_keyboard?: boolean
   is_pointing_device?: boolean
   is_touch_bar?: boolean


### PR DESCRIPTION
This PR adds features and updates from the Karabiner Elements 15.X series.

For example, from KE 15.6.0:

- Added [set_variable.expression and set_variable.key_up_expression](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to/set-variable/#expression-specification).
- Added [expression_if and expression_unless](https://karabiner-elements.pqrs.org/docs/json/complex-modifications--manipulator-definition/conditions/expression/).
- Added [integer_value](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/from/integer-value/) to the from event definition.

Some new key codes are all supported from 15.4.0.