### PR TITLE
feat: Add Karabiner-Elements style JSON formatter with multi-line for…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karabiner.ts",
-  "version": "1.35.1",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karabiner.ts",
-      "version": "1.35.1",
+      "version": "1.38.0",
       "license": "MIT",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.0",

--- a/src/karabiner/json-formatter.test.ts
+++ b/src/karabiner/json-formatter.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from 'vitest';
+
+
+
+import { pqrsFormat } from './json-formatter';
+
+
+describe('pqrsFormat', () => {
+  // --- Primitives ---
+
+  test('formats string', () => {
+    expect(pqrsFormat('hello')).toBe('"hello"')
+  })
+
+  test('formats number', () => {
+    expect(pqrsFormat(42)).toBe('42')
+  })
+
+  test('formats boolean', () => {
+    expect(pqrsFormat(true)).toBe('true')
+  })
+
+  test('formats null', () => {
+    expect(pqrsFormat(null)).toBe('null')
+  })
+
+  test('formats bigint (falls back to String() for unhandled types)', () => {
+    expect(pqrsFormat(1n)).toBe('1')
+  })
+
+  // --- isMultiLine branches ---
+
+  test('formats empty object (isMultiLine: empty keys)', () => {
+    expect(pqrsFormat({})).toBe('{}')
+  })
+
+  test('single-key object with empty object value (isMultiLine: keys.length === 0)', () => {
+    expect(pqrsFormat({ x: {} })).toBe('{ "x": {} }')
+  })
+
+  test('formats multi-element primitive array on single line (isMultiLine: all-primitives loop)', () => {
+    expect(pqrsFormat([1, 2, 3])).toBe('[1, 2, 3]')
+  })
+
+  test('formats single-element object with primitive on single line', () => {
+    expect(pqrsFormat({ key: 'value' })).toBe('{ "key": "value" }')
+  })
+
+  test('formats multi-key object as multi-line (isMultiLine: >1 key)', () => {
+    const result = pqrsFormat({ a: 1, b: 2 })
+    expect(result).toContain('\n')
+    expect(result).toContain('"a": 1')
+    expect(result).toContain('"b": 2')
+  })
+
+  // --- forceMultiLineArrayKeys (isMultiLine: parentKey match) ---
+
+  test('forceMultiLineArrayKeys expands matching array', () => {
+    const result = pqrsFormat(
+      { to: ['a', 'b'] },
+      { forceMultiLineArrayKeys: new Set(['to']) },
+    )
+    expect(result).toContain('\n')
+    expect(result).toContain('"to"')
+  })
+
+  test('forceMultiLineArrayKeys does not affect non-matching key', () => {
+    const result = pqrsFormat(
+      { from: ['a', 'b'] },
+      { forceMultiLineArrayKeys: new Set(['to']) },
+    )
+    expect(result).not.toContain('\n')
+  })
+
+  // --- null / undefined handling ---
+
+  test('formats null in object', () => {
+    const result = pqrsFormat({ a: null })
+    expect(result).toBe('{ "a": null }')
+  })
+
+  test('skips undefined values in object', () => {
+    const result = pqrsFormat({ a: 'keep', b: undefined, c: 3 })
+    expect(result).toContain('"a": "keep"')
+    expect(result).toContain('"c": 3')
+    expect(result).not.toContain('"b"')
+  })
+
+  test('formats object with all undefined values as empty', () => {
+    expect(pqrsFormat({ a: undefined, b: undefined })).toBe('{}')
+  })
+
+  test('filters undefined from array', () => {
+    expect(pqrsFormat([1, undefined, 3])).toBe('[1, null, 3]')
+  })
+
+  test('formats array with all undefined as empty', () => {
+    expect(pqrsFormat([undefined, undefined])).toBe('[null, null]')
+  })
+
+  test('skips undefined in nested structure', () => {
+    const result = pqrsFormat({
+      items: [undefined, { x: 1, y: undefined }],
+    })
+    expect(result).toContain('"x": 1')
+    expect(result).not.toContain('"y"')
+  })
+
+  // --- Empty arrays ---
+
+  test('formats empty array', () => {
+    expect(pqrsFormat([])).toBe('[]')
+  })
+
+  // --- Multi-line arrays with objects ---
+
+  test('formats array with 2+ objects as multi-line', () => {
+    const result = pqrsFormat([{ a: 1 }, { b: 2 }])
+    expect(result).toContain('\n')
+  })
+
+  // --- Multi-line objects ---
+
+  test('sorts object keys alphabetically in multi-line', () => {
+    const result = pqrsFormat({ z: 1, a: 2, m: 3 })
+    const aIdx = result.indexOf('"a"')
+    const mIdx = result.indexOf('"m"')
+    const zIdx = result.indexOf('"z"')
+    expect(aIdx).toBeLessThan(mIdx)
+    expect(mIdx).toBeLessThan(zIdx)
+  })
+
+  // --- Custom indentSize ---
+
+  test('respects custom indentSize', () => {
+    const result = pqrsFormat({ a: 1, b: 2 }, { indentSize: 2 })
+    expect(result).toContain('  "a": 1')
+    expect(result).toContain('  "b": 2')
+    expect(result).not.toContain('    "a"')
+  })
+
+  // --- String escaping ---
+
+  test('escapes special characters in strings', () => {
+    expect(pqrsFormat('he said "hi"')).toBe('"he said \\"hi\\""')
+  })
+
+  // --- Single-element arrays ---
+
+  test('single-element primitive array stays single-line', () => {
+    expect(pqrsFormat([42])).toBe('[42]')
+  })
+
+  test('single-element single-key object array stays single-line', () => {
+    const result = pqrsFormat([{ key: 'val' }])
+    expect(result).toBe('[{ "key": "val" }]')
+  })
+
+  test('single-element multi-key object array expands to multi-line', () => {
+    const result = pqrsFormat([{ a: 1, b: 2 }])
+    expect(result).toContain('\n')
+  })
+
+  // --- Single-key object with nested ---
+
+  test('single-key object with multi-value object stays single-line through recursion', () => {
+    // { a: "v" } → single line
+    expect(pqrsFormat({ a: 'v' })).toBe('{ "a": "v" }')
+  })
+
+  test('single-key object with multi-key value expands', () => {
+    const result = pqrsFormat({ wrapper: { x: 1, y: 2 } })
+    expect(result).toContain('\n')
+  })
+
+  // --- Complex Karabiner-like config ---
+
+  test('formats typical Karabiner config', () => {
+    const result = pqrsFormat({
+      from: { key_code: 'a' },
+      to: [{ key_code: 'b' }],
+    })
+    expect(result).toContain('"from": { "key_code": "a" }')
+    expect(result).toContain('"to"')
+    expect(result).toContain('"key_code": "b"')
+  })
+})

--- a/src/karabiner/json-formatter.ts
+++ b/src/karabiner/json-formatter.ts
@@ -1,0 +1,163 @@
+/**
+ * Karabiner-Elements style JSON formatter
+ *
+ * Ported from pqrs::json::pqrs_formatter (C++)
+ * https://github.com/pqrs-org/Karabiner-Elements/blob/v15.0.0/src/vendor/cget/cget/pkg/pqrs-org__cpp-json/install/include/pqrs/json/pqrs_formatter.hpp
+ *
+ * Rules:
+ * - Arrays stay on a single line by default; but if size >= 2 and contains arrays or objects, they expand to multiple lines.
+ * - Objects with only 1 key and a single-line value stay on a single line (e.g., { "key": "value" }).
+ * - Certain arrays can be forced to expand via forceMultiLineArrayKeys.
+ */
+
+export interface PqrsFormatterOptions {
+  /** Indent size, default is 4 */
+  indentSize?: number
+  /** Specify object keys where arrays should be forced to display in multiple lines */
+  forceMultiLineArrayKeys?: Set<string>
+}
+
+const defaultOptions: Required<PqrsFormatterOptions> = {
+  indentSize: 4,
+  forceMultiLineArrayKeys: new Set(),
+}
+
+/**
+ * Determines whether a JSON value should be displayed in multiple lines
+ */
+function isMultiLine(
+  value: unknown,
+  options: Required<PqrsFormatterOptions>,
+  parentKey?: string,
+): boolean {
+  if (value === null || value === undefined) return false
+
+  if (Array.isArray(value)) {
+    // Parent key is in the force multi-line list
+    if (parentKey && options.forceMultiLineArrayKeys.has(parentKey)) {
+      return true
+    }
+
+    if (value.length === 0) return false
+
+    // If there is only 1 element, recursively judge the element
+    if (value.length === 1) {
+      return isMultiLine(value[0], options)
+    }
+
+    // If there are more than 2 elements, if it contains an array or object, it will be multi-line
+    for (const item of value) {
+      if (typeof item === 'object' && item !== null) {
+        return true
+      }
+    }
+    return false
+  }
+
+  if (typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>)
+
+    if (keys.length === 0) return false
+
+    // If there is only 1 key, recursively judge its value
+    if (keys.length === 1) {
+      return isMultiLine(
+        (value as Record<string, unknown>)[keys[0]],
+        options,
+        keys[0],
+      )
+    }
+
+    // More than 2 keys must be multi-line
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Recursively format JSON values
+ */
+function formatValue(
+  value: unknown,
+  options: Required<PqrsFormatterOptions>,
+  indentLevel: number,
+  parentKey?: string,
+): string {
+  // null
+  if (value === null) return 'null'
+  if (value === undefined) return 'null'
+
+  // Primitive types
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  const indent = ' '.repeat(options.indentSize * indentLevel)
+  const childIndent = ' '.repeat(options.indentSize * (indentLevel + 1))
+
+  // Array
+  if (Array.isArray(value)) {
+    if (!isMultiLine(value, options, parentKey)) {
+      // Single-line array
+      const items = value.map((v) => formatValue(v, options, indentLevel + 1))
+      return `[${items.join(', ')}]`
+    }
+
+    // Multi-line array
+    const items = value.map(
+      (v) => `${childIndent}${formatValue(v, options, indentLevel + 1)}`,
+    )
+    return `[\n${items.join(',\n')}\n${indent}]`
+  }
+
+  // Object
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+
+    if (entries.length === 0) return '{}'
+
+    if (!isMultiLine(value, options, parentKey)) {
+      // Single-line object (only 1 key and the value is single-line)
+      const [k, v] = entries[0]
+      return `{ ${JSON.stringify(k)}: ${formatValue(v, options, indentLevel + 1, k)} }`
+    }
+
+    // Multi-line object
+    const sortedEntries = [...entries].sort(([a], [b]) => a.localeCompare(b))
+    const lines = sortedEntries.map(([k, v]) => {
+      const formattedValue = formatValue(v, options, indentLevel + 1, k)
+      return `${childIndent}${JSON.stringify(k)}: ${formattedValue}`
+    })
+    return `{\n${lines.join(',\n')}\n${indent}}`
+  }
+
+  return String(value)
+}
+
+/**
+ * Formats a JSON value into a compact Karabiner-Elements style JSON string
+ *
+ * @example
+ * ```ts
+ * const json = { from: { key_code: "a" }, to: [{ key_code: "b" }] }
+ * console.log(pqrsFormat(json))
+ * // {
+ * //     "from": { "key_code": "a" },
+ * //     "to": [{ "key_code": "b" }]
+ * // }
+ * ```
+ */
+export function pqrsFormat(
+  json: unknown,
+  options?: PqrsFormatterOptions,
+): string {
+  const resolved: Required<PqrsFormatterOptions> = {
+    indentSize: options?.indentSize ?? defaultOptions.indentSize,
+    forceMultiLineArrayKeys:
+      options?.forceMultiLineArrayKeys ??
+      defaultOptions.forceMultiLineArrayKeys,
+  }
+  return formatValue(json, resolved, 0)
+}

--- a/src/karabiner/json-formatter.ts
+++ b/src/karabiner/json-formatter.ts
@@ -86,6 +86,7 @@ function formatValue(
 ): string {
   // null
   if (value === null) return 'null'
+  // for specific undefined value, return null
   if (value === undefined) return 'null'
 
   // Primitive types
@@ -107,6 +108,7 @@ function formatValue(
 
     // Multi-line array
     const items = value.map(
+      // for undefined value in array, return formatValue(undefined, options, indentLevel + 1),
       (v) => `${childIndent}${formatValue(v, options, indentLevel + 1)}`,
     )
     return `[\n${items.join(',\n')}\n${indent}]`
@@ -115,6 +117,9 @@ function formatValue(
   // Object
   if (typeof value === 'object') {
     const entries = Object.entries(value as Record<string, unknown>)
+      // for undefined value in object, skip it
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b))
 
     if (entries.length === 0) return '{}'
 
@@ -125,8 +130,7 @@ function formatValue(
     }
 
     // Multi-line object
-    const sortedEntries = [...entries].sort(([a], [b]) => a.localeCompare(b))
-    const lines = sortedEntries.map(([k, v]) => {
+    const lines = entries.map(([k, v]) => {
       const formattedValue = formatValue(v, options, indentLevel + 1, k)
       return `${childIndent}${JSON.stringify(k)}: ${formattedValue}`
     })

--- a/src/output.ts
+++ b/src/output.ts
@@ -5,6 +5,7 @@ import {
 import { ManipulatorBuilder, ManipulatorMap } from './config/manipulator.ts'
 import { RuleBuilder } from './config/rule.ts'
 import { simpleModifications } from './config/simple-modifications.ts'
+import { pqrsFormat } from './karabiner/json-formatter.ts'
 import {
   KarabinerConfig,
   Manipulator,
@@ -104,7 +105,7 @@ export function writeToProfile(
     }
   }
 
-  let json = JSON.stringify(config, null, 2)
+  let json = pqrsFormat(config, { indentSize: 4 })
 
   if (dryRun) {
     console.info(json)
@@ -135,7 +136,7 @@ export function writeToGlobal(
   let jsonPath = karabinerJsonPath ?? writeContext.karabinerConfigFile()
   let config: KarabinerConfig = writeContext.readKarabinerConfig(jsonPath)
   config.global = { ...config.global, ...global }
-  let json = JSON.stringify(config, null, 2)
+  let json = pqrsFormat(config, { indentSize: 4 })
 
   writeContext.writeKarabinerConfig(json, jsonPath).catch(exitWithError)
 


### PR DESCRIPTION
implement custom formatter aligned with Karabiner-Elements v15.0.0+

Starting from v15.0.0, Karabiner-Elements applies a specific key ordering and indentation format when updating karabiner.json via the UI. This previously caused unnecessary diffs when comparing GUI-generated files with programmatic exports.

Ported the official C++ formatter logic (`pqrs::json::pqrs_formatter`) to JS/TS:
https://github.com/pqrs-org/Karabiner-Elements/blob/v15.0.0/src/vendor/cget/cget/pkg/pqrs-org__cpp-json/install/include/pqrs/json/pqrs_formatter.hpp

Now, programmatically generated configurations will match the exact formatting of the native app, enabling clean and accurate diff comparisons.
